### PR TITLE
Fix "OEM-specific Type" and "Group Associations" parsing

### DIFF
--- a/bin/dmij
+++ b/bin/dmij
@@ -20,7 +20,7 @@ quote() {
     WHAT="${WHAT/[[:space:]]/}"
     WHAT=$(echo $WHAT | tr -d '\t') # remove tabs
     [[ $WHAT && ${IGNORE[${WHAT,,}]} ]] && WHAT=""
-    [[ $WHAT || $LABEL ]] || continue
+    [[ $WHAT || $LABEL ]] || return
 
     # enforce quoting on values that could look like numbers
     [[ $LABEL =~ BIOSRevision || $LABEL =~ Version || $LABEL =~ Description || $LABEL =~ Address || $LABEL =~ Serial || $LABEL == "Rank" ]] && echo -n "${PREFIX}\"$WHAT\"" && return

--- a/bin/dmij
+++ b/bin/dmij
@@ -41,7 +41,7 @@ tojson() {
 
 TMPDIR=$(mktemp -d)
 
-REJECT="^(Inactive|Table|End Of Table|SMBIOS|#|[0-9])"
+REJECT="^(Inactive|Table|End Of Table|SMBIOS|Group Associations|OEM-specific Type|#|[0-9])"
 
 declare -A IGNORE=(
 	["unknown"]=true
@@ -60,7 +60,13 @@ while IFS= read -r LINE
 do
     #LINE=$(echo $LINE | tr -d '\t') # remove tabs
     [[ $LINE ]] || continue
-    [[ $LINE =~ $REJECT ]]  && continue
+    if [[ $LINE =~ $REJECT ]]; then
+        while IFS= read -r LINE
+        do
+            [[ -z $LINE ]] && break
+        done
+        continue
+    fi
     [[ $LINE =~ ^Handle ]]  && HANDLE="${LINE:7:6}" && continue
     [[ $LINE =~ ^[A-Z] ]]   && TAG=${LINE//[[:space:]]/} && continue
     unset SKIP


### PR DESCRIPTION
For example, on my laptop (5th gen Thinkpad X1 Carbon), `dmidecode` outputs something along these lines:

```
...

Handle 0x003A, DMI type 140, 43 bytes
OEM-specific Type
	Header and Data:
		8C 2B 3A 00 4C 45 4E 4F 56 4F 0B 08 01 FF FF FF
		FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF
		FF FF FF FF FF FF FF FF FF FF FF

Handle 0x003B, DMI type 14, 8 bytes
Group Associations
	Name: $MEI
	Items: 1
		0x0000 (OEM-specific)

...
```

Both of these types are incorrectly parsed by dmijson. This PR fixes this issue.